### PR TITLE
Bump to Quarkus 1.13.0 and build a uber-jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,9 @@
   <version>1.0.0-SNAPSHOT</version>
 
   <properties>
-    <quarkus-plugin.version>1.10.5.Final</quarkus-plugin.version>
+    
+    <quarkus-plugin.version>1.13.0.Final</quarkus-plugin.version>
+    <quarkus.package.type>uber-jar</quarkus.package.type>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
     <quarkus.platform.version>1.10.5.Final</quarkus.platform.version>


### PR DESCRIPTION
The uber-jar includes all the dependencies and our code inside the final jar. This makes deployment much easier.